### PR TITLE
PageRTC: keep the last good date and time after read failures

### DIFF
--- a/src/PageRTC.hpp
+++ b/src/PageRTC.hpp
@@ -52,8 +52,11 @@ struct PageRTC : public PageBase
   {
     if (_editIdx < 0 || _editIdx >= 6)
     {
-      _date = M5.Rtc.getDate();
-      _time = M5.Rtc.getTime();
+      // bool 版 getter は失敗時に out-param を更新しないので、読み失敗や
+      // 不正データの際は前回の正常値が保持される。1 回の呼び出しに纏めるのは
+      // date だけ成功・time だけ失敗という新旧混在を避けるため。
+      // (戻り値版は失敗を無視して負のセンチネル値を返すため使わない)
+      M5.Rtc.getDateTime(&_date, &_time);
     }
     if (justTouch)
     {
@@ -197,15 +200,19 @@ private:
 
   m5::rtc_time_t _wake_timer;
 
-  void drawNumber(LovyanGFX* gfx, const m5gfx::rgb565_t* img, int x, int y, size_t val, int int_digit)
+  void drawNumber(LovyanGFX* gfx, const m5gfx::rgb565_t* img, int x, int y, int val, int int_digit)
   {
+    // 初回読み取り前の初期値など、負値は空白 (グリフ10) で埋める。
+    // 旧実装は size_t 受けだったため負値が大きな符号なし値になり、
+    // フィールド外まで余分な桁を描いて残留していた。
+    const bool blank = (val < 0);
     do
     { // 低い桁から順に描画
       x -= 12;
-      size_t num = (val % 10);
+      int num = blank ? 10 : (val % 10);
       gfx->pushImage(x, y, 12, 20, img + 12 * 20 * num);
-      val = val / 10;
-    } while (--int_digit > 0 || val);
+      val = blank ? 0 : val / 10;
+    } while (--int_digit > 0 || val > 0);
   }
 
   bool flickValue(void)


### PR DESCRIPTION
On the RTC page, the time display could suddenly grow far beyond its field
and the extra digits then stayed on screen until the page was redrawn.

The page reads the clock with the value-returning `getTime` / `getDate`
helpers, which ignore a failed RTC transaction and return fields initialized
to negative sentinel values. `drawNumber` took the value as `size_t`, so a
negative field became a large unsigned value and the digit loop walked left
across the screen, and nothing overwrites that area on later frames.
Any failed or rejected RTC read could trigger it, since the drivers also
return failure for values that do not decode as valid BCD.

Two changes:

- Read the clock with the boolean `getDateTime` overload. On failure the
  out-parameters are left untouched, so the display keeps the last
  successfully read date and time, and reading both parts in one call avoids
  mixing a fresh date with a stale time.
- `drawNumber` takes a signed value and renders a negative one with blank
  glyphs, covering the initial sentinel values before the first successful
  read.

Verified on ToughC5 hardware, and both PlatformIO environments build.
