### PR TITLE
platformio.ini: pin the platform to release 55.03.37

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,7 +5,9 @@ default_envs = m5tools_core2_tough
 ; 全 env で同一の platform を使う。異なる platform を混在させると
 ; framework-arduinoespressif32 のディレクトリを奪い合い、env 切替のたびに
 ; 再取得が走って FRAMEWORK_DIR の解決に失敗することがある。
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; stable エイリアスは中身が随時進むため、検証済みのリリースに固定する
+; (55.03.311 では arduino-core 3.3.11 になり ESP32 classic の IRAM が溢れる)
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 framework = arduino
 monitor_speed = 115200
 build_src_filter =


### PR DESCRIPTION
The `platform` entry points at pioarduino's moving `stable` zip. That
alias currently delivers 55.03.311, whose arduino-core 3.3.11 makes the
ESP32 classic environment fail at link time:

```
ld: region `iram0_0_seg' overflowed by 1380 bytes
```

A fresh checkout therefore no longer builds for Core2/Tough. Pin the
platform to release 55.03.37, the version this project is verified
against (the ToughC5 environment builds with both, the classic
environment only with 55.03.37).
