### PR TITLE
Sliders: wait for DMA before reusing the frame canvas

### DIFF
--- a/src/PageRTC.hpp
+++ b/src/PageRTC.hpp
@@ -131,6 +131,10 @@ struct PageRTC : public PageBase
     if (_prev_x != _slide_x || _editIdx >= 6)
     {
       _prev_x = _slide_x;
+      /// The write transaction stays held, so pushSprite() returns with DMA
+      /// still reading this canvas. Wait just before overwriting it so the
+      /// transfer overlaps with input handling. (waitDisplay() is a no-op on LCD)
+      M5.Lcd.waitDMA();
       _canvas_base.pushImage(-13, -124, 288, 168, (m5gfx::rgb565_t*)gImage_rtcBk);
       auto img = (const m5gfx::rgb565_t*)gImage_rtcNumberGray;
       drawNumber(&_canvas_base, img, 106, 11, _wake_timer.hours, 2);

--- a/src/src.ino
+++ b/src/src.ino
@@ -201,6 +201,10 @@ Serial.print("done");
         if (prev_x != slide_x)
         {
           prev_x = slide_x;
+          /// The write transaction stays held, so pushSprite() returns with DMA
+          /// still reading this canvas. Wait just before overwriting it so the
+          /// transfer overlaps with input handling. (waitDisplay() is a no-op on LCD)
+          M5.Lcd.waitDMA();
           _canvas_base.pushImage(-32, -80, 320, 240, (m5gfx::rgb565_t*)gImage_sleepBk);
           _canvas_bk.pushSprite(&_canvas_base, 0, 0);
           _canvas_base.fillRect(28, 0, slide_x, 56, 0x555555u);


### PR DESCRIPTION
Dragging the sleep slider (and the RTC wake-timer slider) showed visible
flicker on ToughC5, while the original Tough looked mostly fine.

Both sliders compose each frame into a canvas sprite and push it to the
LCD. The app keeps `startWrite()` held for its whole lifetime, so
`pushSprite` returns while the DMA transfer is still reading the canvas.
The loop then immediately composes the next frame into the same canvas,
overwriting the data mid-transfer, and the corrupted rows appear as
flicker. How visible this is depends on how soon the next composition
starts inside the transfer window, which is why the faster loop of the
C5 build made it prominent - the race itself exists on every target.

The fix calls `waitDMA()` right before the first canvas write of the
next frame, so the wait overlaps with input handling instead of adding
dead time after the push. Note that `waitDisplay()` cannot be used for
this: it is an e-paper busy-wait API and a no-op on LCD panels (verified
by measurement: it returned in ~2 us while the transfer was in flight,
whereas the full push takes ~5.7 ms at 40 MHz).

As a side effect the release animation regains its intended speed on
fast targets: the per-loop decay is now naturally paced by the wait for
the previous frame's transfer instead of free-running.

Verified on ToughC5 (flicker gone, dragging stays smooth) and on the
original Tough, and both PlatformIO environments build.
