### PR TITLE
PageUART: read the displayed MAC addresses from efuse

### DIFF
--- a/src/PageUART.hpp
+++ b/src/PageUART.hpp
@@ -3,6 +3,7 @@
 #include "main.hpp"
 
 #include <memory>
+#include <esp_mac.h>
 #include <esp_now.h>
 #include <esp_idf_version.h>
 #if !M5TOOLS_TARGET_ESP32C5
@@ -212,8 +213,14 @@ struct PageUART : public PageBase
   void setup(void) override
   {
     static constexpr char format[] = "%02x%02x%02x%02x%02x%02x";
-    uint8_t mac[6];
-    WiFi.macAddress(mac);
+    /// WiFi.macAddress() は WiFi 未初期化だとバッファへ書かずに失敗する
+    /// (起動直後に開くとスタックのゴミが表示される) ため、efuse 直読の
+    /// esp_read_mac() を使う。BLE/BT が実際に使うのはオフセット付きの
+    /// BT MAC なので、行ごとに対応するアドレスを表示する
+    uint8_t mac_bt[6];
+    uint8_t mac_sta[6];
+    esp_read_mac(mac_bt, ESP_MAC_BT);
+    esp_read_mac(mac_sta, ESP_MAC_WIFI_STA);
     _canvas_source.setPsram(true);
     _canvas_source.createSprite(sourceWidth, sourceHeight * sourceCount);
     _canvas_source.fillSprite(TFT_WHITE);
@@ -224,6 +231,7 @@ struct PageUART : public PageBase
       _canvas_source.pushImage(0, i * sourceHeight, sourceImgWidth, sourceHeight, (m5gfx::swap565_t*)gImage_uartPort + id * sourceImgWidth * sourceHeight);
       if (id == ss_ble || id == ss_bt || id == ss_espnow)
       {
+        auto mac = (id == ss_espnow) ? mac_sta : mac_bt; // ESP-NOW は STA MAC を使う
         _canvas_source.setFont(&fonts::Font0);
         _canvas_source.setTextSize(1,2);
         _canvas_source.setCursor(24, sourceHeight * i + 2);


### PR DESCRIPTION
Opening the UART page right after boot showed a wrong MAC address on the
BLE/BT/ESP-NOW source rows, while visiting the WiFi page first made it
correct.

The page read the address with `WiFi.macAddress(mac)` into an
uninitialized local buffer. With the arduino-esp32 3.x Network API this
call fails without touching the buffer while the WiFi driver is not
initialized (`NetworkInterface::macAddress()` returns NULL when the
netif does not exist yet - unlike the 2.x core, which fell back to
`esp_read_mac()`), so the page printed stack garbage. Visiting the WiFi
page first initialized the driver and hid the problem.

Read the addresses with `esp_read_mac()`, which reads efuse directly and
works regardless of the driver state. While here, show each row the
address it actually uses: BLE and BT use the BT MAC (which has a
chip-specific offset from the base address), and ESP-NOW uses the
station MAC. Previously all three rows showed the station MAC.

Verified on ToughC5 and the original Tough: the value is stable from a
cold boot and stays the same after visiting the WiFi page, and the
BLE/BT rows now show the offset BT MAC as expected. Both PlatformIO
environments build.
