### PR TITLE
Show progress while waiting on WiFi scans and TF card retries

### DIFF
--- a/src/PageTF.hpp
+++ b/src/PageTF.hpp
@@ -37,12 +37,24 @@ struct PageTF : public PageBase
                     (int)ioe.digitalRead(13), (int)ioe.digitalRead(5));
 #endif
       const int tf_ss_pin = M5.getPin(m5::pin_name_t::sd_spi_ss);
-      int retry = 5;
-      do
+      constexpr int retry_max = 5;
+      bool opened = false;
+      bool canceled = false;
+      for (int attempt = 1; ; ++attempt)
       {
         SD.end();
-      } while (!SD.begin(tf_ss_pin, SPI, 25000000) && --retry);
-      if (retry)
+        opened = SD.begin(tf_ss_pin, SPI, 25000000);
+        if (opened || attempt >= retry_max) { break; }
+        /// 何度目の試行かを見せる。試行の合間はタッチで中断できる
+        M5.Lcd.printf("retry %d/%d ...\r\n", attempt + 1, retry_max);
+        updateTouch();
+        if (prev_touchPoints < touchPoints)
+        {
+          canceled = true;
+          break;
+        }
+      }
+      if (opened)
       {
         auto root = SD.open("/");
         if (!showFiles(root))
@@ -53,7 +65,7 @@ struct PageTF : public PageBase
       }
       else
       {
-        M5.Lcd.println("TF card open failure .");
+        M5.Lcd.println(canceled ? "TF card open canceled ." : "TF card open failure .");
       }
       M5.Lcd.clearScrollRect();
       M5.Lcd.setTextScroll(false);

--- a/src/PageWiFi.hpp
+++ b/src/PageWiFi.hpp
@@ -9,23 +9,55 @@ struct PageWiFi : public PageBase
   void setup(void) override
   {
     M5.Lcd.pushImage(220, 120, 80, 80 , (m5gfx::rgb565_t*)gImage_ScanWiFi);
+    _scanning = false;
   }
   void loop(void) override
   {
-    if (justTouch && (tp[0].y > 120) && (tp[0].y < 200) && (tp[0].x > 220) && (tp[0].x < 320))
+    if (!_scanning
+     && justTouch && (tp[0].y > 120) && (tp[0].y < 200) && (tp[0].x > 220) && (tp[0].x < 320))
     {
       clickSound();
       M5.Lcd.setFont(&fonts::Font2);
       M5.Lcd.fillRect(20, 35, 200, 165, TFT_WHITE);
       M5.Lcd.setTextColor(TFT_BLACK, TFT_WHITE);
-      M5.Lcd.setCursor(20, 32);
-      M5.Lcd.printf("Scanning ......");
 
       WiFi.mode(WIFI_STA);
       WiFi.disconnect();
-      int n = WiFi.scanNetworks();
+      /// スキャンは非同期で開始し、完了は loop 側でポーリングする。
+      /// 同期版はバンド全チャンネル分ブロックし (5GHz 対応機は特に長い)、
+      /// その間タッチも表示も止まってしまう
+      WiFi.scanNetworks(true);
+      _scanning = true;
+      _anim = 0;
+      _anim_ms = millis() - 1000; // 最初のフレームを即描く
+    }
+    if (_scanning)
+    {
+      int n = WiFi.scanComplete();
+      if (n == WIFI_SCAN_RUNNING)
+      {
+        if (millis() - _anim_ms >= 250)
+        { /// 待機中であることが分かるようドットを回す
+          _anim_ms = millis();
+          M5.Lcd.setFont(&fonts::Font2);
+          M5.Lcd.setTextColor(TFT_BLACK, TFT_WHITE);
+          M5.Lcd.setCursor(20, 32);
+          M5.Lcd.printf("Scanning %-6.*s", (int)(_anim + 1), "......");
+          _anim = (_anim + 1) % 6;
+        }
+        return;
+      }
+      _scanning = false;
+      M5.Lcd.setFont(&fonts::Font2);
       M5.Lcd.setCursor(20, 32);
-      M5.Lcd.printf("Total : %d found.", n);
+      if (n < 0)
+      {
+        M5.Lcd.setTextColor(TFT_RED, TFT_WHITE);
+        M5.Lcd.printf("Scan failed.         ");
+        return;
+      }
+      M5.Lcd.setTextColor(TFT_BLACK, TFT_WHITE);
+      M5.Lcd.printf("Total : %d found.     ", n);
       for (int i = 0; i < 10; i++)
       {
         M5.Lcd.setCursor(20, 50 + 15 * i);
@@ -37,4 +69,9 @@ struct PageWiFi : public PageBase
   void end(void) override
   {
   }
+
+private:
+  bool _scanning = false;
+  uint32_t _anim_ms = 0;
+  uint8_t _anim = 0;
 };


### PR DESCRIPTION
Two waits in the app looked like a freeze with no way to tell whether
anything was still happening:

- The WiFi page blocked inside the synchronous `scanNetworks()` with a
  static "Scanning" caption. On dual-band targets the scan covers both
  2.4 GHz and 5 GHz channels, so the freeze is long.
- The TF page silently retried `SD.begin()` up to five times, which
  takes several seconds when no card is inserted.

WiFi page: the scan now starts asynchronously and the page polls
`scanComplete()` from its loop, animating a dot indicator while the scan
runs. Touch stays responsive the whole time (switching pages mid-scan is
safe), and a failed scan is reported as such instead of showing zero
results.

TF page: a `retry n/5 ...` line is printed before each attempt, and a
touch between attempts cancels the remaining retries. The attempts
themselves still block: running them in a background task would need
extra locking because the TF card and the LCD share the SPI bus on
ToughC5, which is not worth it for this page.

Verified on ToughC5 and the original Tough: scan indicator animates and
results render as before, retry counter and cancel work with no card
inserted, and a present card opens as before. Both PlatformIO
environments build.
