### PR TITLE
Power light turns off before scheduled sleep, and power light turns off after sliding shutdown; resolves the issue of the first directory on the SD card being skipped.

### DIFF
--- a/src/PageRTC.hpp
+++ b/src/PageRTC.hpp
@@ -176,6 +176,7 @@ struct PageRTC : public PageBase
     if (_slide_x == 206)
     {
       int timer = _wake_timer.hours * 3600 + _wake_timer.minutes * 60 + _wake_timer.seconds;
+      prepareForPowerDown();
       M5.Power.timerSleep(timer);
     }
     else

--- a/src/PageTF.hpp
+++ b/src/PageTF.hpp
@@ -87,19 +87,26 @@ struct PageTF : public PageBase
 private:
   bool showFiles(File dir)
   {
-    File fp =  dir.openNextFile();
     bool abort = false;
-    while ((bool)(fp = dir.openNextFile()))
+    while (true)
     {
+      File fp = dir.openNextFile();
+      if (!fp) { break; }
+
       updateTouch();
       abort = (prev_touchPoints < touchPoints);
-      if (abort) break;
+      if (abort)
+      {
+        fp.close();
+        break;
+      }
       M5.Lcd.print(fp.name());
       if (fp.isDirectory())
       {
         M5.Lcd.println("/");
         if (!showFiles(fp))
         {
+          fp.close();
           abort = true;
           break;
         }
@@ -108,6 +115,7 @@ private:
       {
         M5.Lcd.println();
       }
+      fp.close();
     }
     dir.rewindDirectory();
     return !abort;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -122,6 +122,14 @@ static void buzzerFlush(void)
 
 #endif
 
+static void prepareForPowerDown(void)
+{
+#if M5TOOLS_TARGET_ESP32C5
+  buzzerStop();
+  M5.Power.M5pm1.setLedEnLevel(false);
+#endif
+}
+
 void clickSound(void)
 {
 #if M5TOOLS_TARGET_ESP32C5

--- a/src/src.ino
+++ b/src/src.ino
@@ -243,6 +243,7 @@ Serial.print("done");
 #if M5TOOLS_TARGET_ESP32C5
           /// wakeup ピン (PM1 の IRQ 出力) の解放待ちを含む M5Unified 側の
           /// 手順に任せる (タッチ・電源ボタン・RTC アラームのいずれでも復帰可能)
+          prepareForPowerDown();
           delay(100);
           M5.Lcd.fillScreen(TFT_BLACK);
           M5.Power.deepSleep(m5::Power_Class::sleep_no_timer, true);


### PR DESCRIPTION
I discovered two issues when using ToughC5：
1、The LED_EN output of M5PM1 was not turned off before shutting down the device or going into sleep mode.
2、PageTF::showFiles() called openNextFile() once before entering the loop, and again within the loop, resulting in the first directory item being skipped.
Revised content
Add a unified prepareForPowerDown() handler: Stop the PM1 PWM buzzer.
Call M5.Power.M5pm1.setLedEnLevel(false) to turn off the power indicator light.

Call this function before sliding off power and RTC timed sleep.
Correct the SD card directory traversal to ensure the first file or directory is displayed normally.
Close the File handle in time during the traversal process.